### PR TITLE
Move some labels, add mywine for better Singularity support w/o root privs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# pwiz installer
+pwiz-bin-windows-*.tar.bz2
+
+# Editor backup files
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,3 +54,6 @@ CMD ["wine64_anyuser", "msconvert" ]
 
 ## If you need a proxy during build, don't put it into the Dockerfile itself:
 ## docker build --build-arg http_proxy=http://proxy.example.com:3128/  -t repo/image:version .
+
+ADD mywine /usr/bin/
+RUN chmod ugo+rx /usr/bin/mywine

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:16.04
 
+LABEL description="Wine with .NET"
+LABEL website=https://github.com/ProteoWizard/container/dotnet
+LABEL documentation=https://github.com/ProteoWizard/container/dotnet
+LABEL license=https://github.com/ProteoWizard/container/dotnet
+LABEL tags="Wine,.NET"
+
+ENV CONTAINER_GITHUB=https://github.com/ProteoWizard/container/dotnet
+
 # Prevents annoying debconf errors during builds
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -58,14 +66,8 @@ RUN mkdir -p /wineprefix64/
 ENV WINEPREFIX /wineprefix64
 WORKDIR /wineprefix64
 
-# Install dependencies
+# Install Windows dependencies
 #ADD winetricks_cache /root/.cache/winetricks
 RUN winetricks -q dotnet472 && wineserver -w && winetricks -q win7 && xvfb-run winetricks -q vcrun2008 vcrun2017 corefonts && wineserver -w && rm -fr /root/.cache/winetricks
 
-ENV CONTAINER_GITHUB=https://github.com/ProteoWizard/wine-dotnet
 
-LABEL description="Wine with .NET"
-LABEL website=https://github.com/ProteoWizard/wine-dotnet
-LABEL documentation=https://github.com/ProteoWizard/wine-dotnet
-LABEL license=https://github.com/ProteoWizard/wine-dotnet
-LABEL tags="Wine,.NET"

--- a/mywine
+++ b/mywine
@@ -3,10 +3,12 @@
 GLOBALWINEPREFIX=/wineprefix64
 MYWINEPREFIX=/mywineprefix/
 
-mkdir -p "$MYWINEPREFIX"/dosdevices
-cp -v "$GLOBALWINEPREFIX"/*.reg "$MYWINEPREFIX"
-ln -s "$GLOBALWINEPREFIX/drive_c" "$MYWINEPREFIX/dosdevices/c:"
-ln -s "/" "$MYWINEPREFIX/dosdevices/z:"
+if [ ! -L "$MYWINEPREFIX"/dosdevices/z: ] ; then 
+  mkdir -p "$MYWINEPREFIX"/dosdevices
+  cp "$GLOBALWINEPREFIX"/*.reg "$MYWINEPREFIX"
+  ln -sf "$GLOBALWINEPREFIX/drive_c" "$MYWINEPREFIX/dosdevices/c:"
+  ln -sf "/" "$MYWINEPREFIX/dosdevices/z:"
+fi 
 
 export WINEPREFIX=$MYWINEPREFIX
 wine "$@"

--- a/mywine
+++ b/mywine
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+GLOBALWINEPREFIX=/wineprefix64
+MYWINEPREFIX=/mywineprefix/
+
+mkdir -p "$MYWINEPREFIX"/dosdevices
+cp -v "$GLOBALWINEPREFIX"/*.reg "$MYWINEPREFIX"
+ln -s "$GLOBALWINEPREFIX/drive_c" "$MYWINEPREFIX/dosdevices/c:"
+ln -s "/" "$MYWINEPREFIX/dosdevices/z:"
+
+export WINEPREFIX=$MYWINEPREFIX
+wine "$@"


### PR DESCRIPTION
Hi, 
this PR is addressing #1 . Main change here is `mywine` which populates a separate `/mywineprefix/` 
directory (writeable for the executing user) with 1) copies of the wine registry files 
and 2) symbolic links to the `dosdevices`. Hence `wine` does not complain anymore 
that `$WINEPREFIX` were not owned by the (non-root) user. 

The result should be usable like this:
```
singularity shell -B /nfs/data/:/data -B `mktemp -d /dev/shm/wineXXX`:/mywineprefix /tmp/singularity/chambm_pwiz-skyline-i-agree-to-the-vendor-licenses.simg
```
Yours, Steffen