### PR TITLE
Revert "Upgrade Wine to 7.0-stable and .NET to 4.8"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get -y install unzip bzip2
@@ -8,7 +8,7 @@ ADD SkylineTester.zip /
 RUN unzip SkylineTester.zip && mv /SkylineTester\ Files/* /wineprefix64/drive_c/pwiz/skyline && rm -fr /wineprefix64/drive_c/pwiz/skyline/TestZipFiles
 
 
-FROM chambm/wine-dotnet:wine7-net4.8-x64
+FROM chambm/wine-dotnet:4.7-x64
 COPY --from=0 /wineprefix64/drive_c/pwiz /wineprefix64/drive_c/pwiz
 
 ENV CONTAINER_GITHUB=https://github.com/ProteoWizard/container

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:16.04
 
 LABEL description="Wine with .NET"
 LABEL website=https://github.com/ProteoWizard/container/dotnet
@@ -34,12 +34,12 @@ RUN dpkg --add-architecture i386 \
       /usr/share/locale \
       /usr/share/zoneinfo
 
-ENV WINEDISTRO=stable
-ENV WINEVERSION=7.0.0.0~focal-1
+ENV WINEDISTRO=devel
+ENV WINEVERSION=3.12.0~xenial
 
 # Install wine
-RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key \
-    && apt-key add winehq.key \
+RUN wget -nc https://dl.winehq.org/wine-builds/Release.key \
+    && apt-key add Release.key \
     && apt-get update \
     && apt-get install -y apt-transport-https \
     && add-apt-repository https://dl.winehq.org/wine-builds/ubuntu/ \
@@ -68,6 +68,6 @@ WORKDIR /wineprefix64
 
 # Install Windows dependencies
 #ADD winetricks_cache /root/.cache/winetricks
-RUN winetricks -q dotnet48 && wineserver -w && winetricks -q win7 && xvfb-run winetricks -q vcrun2008 vcrun2017 corefonts && wineserver -w && rm -fr /root/.cache/winetricks
+RUN winetricks -q dotnet472 && wineserver -w && winetricks -q win7 && xvfb-run winetricks -q vcrun2008 vcrun2017 corefonts && wineserver -w && rm -fr /root/.cache/winetricks
 
 


### PR DESCRIPTION
Reverts ProteoWizard/container#15

The Wine upgrade fixed the Baf2Sql 2.9 failure, but causes a new failure in at least one Skyline test.