### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && \
     apt-get -y install sudo && \
     apt-get -y clean && \
     echo "ALL     ALL=NOPASSWD:  ALL" >> /etc/sudoers && \
-    echo '#!/bin/sh\nsudo -E -u root wine64 "$@"' > /usr/bin/wine64_anyuser && \
-    echo '#!/bin/sh\nsudo -E -u root wine "$@"' > /usr/bin/wine_anyuser && \
+    echo '#!/bin/sh\nsudo -E -H -u root wine64 "$@"' > /usr/bin/wine64_anyuser && \
+    echo '#!/bin/sh\nsudo -E -H -u root wine "$@"' > /usr/bin/wine_anyuser && \
     chmod ugo+rx /usr/bin/wine*anyuser && \
     rm -rf \
       /var/lib/apt/lists/* \


### PR DESCRIPTION
### Change on the wine64_anyuser or wine_anyuser command

**Problem:**
We are currently implementing a workflow to convert RAW files to mzml with verifications .
(The implementation involves the use of folder directory as an input- as an intermediate state)

Currently we are facing the following issue
![image](https://github.com/ProteoWizard/container/assets/87706210/43db8113-cb66-41a5-91c9-955facbc08b6)

![image](https://github.com/ProteoWizard/container/assets/87706210/e56581ef-16eb-43df-a157-1e4ea3265b0b)

On second picture, we could see the ".config" folder being copied from container to local system.

**SOLUTION:**

To address the issue, we tried adding the "-H" command on existing wine64_anyuser command that sets Home environment variable.
And due to which the folder ".config" or ".local " is not seen on the local system.

Our suggestions:

1) adding "-H" on existing commands:
wine64_anyuser
--> sudo -E -u root wine64 "$@"
or

creating a separate command line
win64_anyuser_cwl where
win64_anyuser_cwl
--> sudo -E -H -u root wine64 "$@"