### PR TITLE
Changes to support running image using apptainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,7 @@ CMD ["wine64_anyuser", "msconvert" ]
 
 ADD mywine /usr/bin/
 RUN chmod ugo+rx /usr/bin/mywine
+
+# Fixes for running as non-root user
+RUN mkdir -p /mywineprefix && chmod 777 /mywineprefix
+RUN mkdir -p /net && chmod 777 /net

--- a/mywine
+++ b/mywine
@@ -8,6 +8,8 @@ if [ ! -L "$MYWINEPREFIX"/dosdevices/z: ] ; then
   cp "$GLOBALWINEPREFIX"/*.reg "$MYWINEPREFIX"
   ln -sf "$GLOBALWINEPREFIX/drive_c" "$MYWINEPREFIX/dosdevices/c:"
   ln -sf "/" "$MYWINEPREFIX/dosdevices/z:"
+  echo disable > $MYWINEPREFIX/.update-timestamp # this line prevents auto update
+  echo disable > $GLOBALWINEPREFIX/.update-timestamp
 fi 
 
 export WINEPREFIX=$MYWINEPREFIX


### PR DESCRIPTION
**Overview**
Container changes to support running the image using apptainer or singularity (where the container will not be run as root).

**How to build and push an image to test these changes**
1. Download the proteowizard tar file from https://teamcity.labkey.org/buildConfiguration/bt83?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds
   1. Click on the latest build from master, select the _Artifacts_ tab 
   2. Download the file named similar to pwiz-bin-windows-x86_64-vc143-release-3_0_XXXXX_XXXXXXX.tar.bz2
1. Download the SkylineTester zip file from https://teamcity.labkey.org/buildConfiguration/bt209?mode=branches
   1. Click the latest build from master, select the _Artifacts_ tab
   2. Download the file named SkylineTester.zip
1. Copy the files in the same directory as the Dockerfile 
1. Build the image by running `docker build -t pwiz-skyline-non-root .` This will create an image named `pwiz-skyline-non-root`
1. Push this test image to a image repository of your choosing 

Once this is done, you should be able to pull and run this image using apptainer.

These changes were made and tested after reviewing the work of https://github.com/jspaezp/elfragmentador-data#setting-up-msconvert-on-singularity-