### PR TITLE
Support running image on Apptainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,4 @@ RUN chmod ugo+rx /usr/bin/mywine
 # Fixes for running the container in apptainer. 
 # Sets the TEMP and TMP environment variables for the wine user to Z:\tmp
 # Z:\tmp in wine maps to /tmp on the host operating system in apptainer 
-ADD set-apptainer-tmp /root
-RUN cat /root/set-apptainer-tmp >> /wineprefix64/user.reg
+RUN /bin/sh -c echo "\"TMP\"=\"Z:\\\\\\\\tmp\""

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,3 +57,9 @@ CMD ["wine64_anyuser", "msconvert" ]
 
 ADD mywine /usr/bin/
 RUN chmod ugo+rx /usr/bin/mywine
+
+# Fixes for running the container in apptainer. 
+# Sets the TEMP and TMP environment variables for the wine user to Z:\tmp
+# Z:\tmp in wine maps to /tmp on the host operating system in apptainer 
+ADD set-apptainer-tmp /root
+RUN cat /root/set-apptainer-tmp >> /wineprefix64/user.reg

--- a/set-apptainer-tmpdir
+++ b/set-apptainer-tmpdir
@@ -1,0 +1,2 @@
+"TEMP"="Z:\\tmp"
+"TMP"="Z:\\tmp"

--- a/set-apptainer-tmpdir
+++ b/set-apptainer-tmpdir
@@ -1,2 +1,0 @@
-"TEMP"="Z:\\tmp"
-"TMP"="Z:\\tmp"


### PR DESCRIPTION
**Overview**
Container changes to support running the image using apptainer or singularity. 

With this change we set the `TEMP` and `TMP` variables in Wine to use a writable drive, when running in Apptainer. The variables are set to be `Z:\tmp` in Wine, which maps to `/tmp` in the container.

Implementation Questions:
1. Should these changes be made in the Dockerfile used to create the `proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses` image or should we create a separate Dockerfile (and image) which enables support for Singularity/Apptainer? 
   - Using a separate Dockerfile and image, may make testing updates (such as updating the version of Wine) easier as there will be less platforms to test on.
2. If we keep these changes in `Dockerfile`, should I change the name `set-apptainer-tmpdir` to something more generic?


**Testing**
- [x] Test running msconvert while running this image in Docker
- [x] Test running skyline while running this image in Docker
- [x] Test running msconvert while running this image in Apptainer
- [x] Test running skyline while running this image in Apptainer


These changes were made and tested after reviewing the work of https://github.com/unlhcc/singularity-dockerfiles/blob/master/skylinerunner/user.reg.patch
